### PR TITLE
Clean up UserlogsHelper

### DIFF
--- a/administrator/components/com_userlogs/helpers/userlogs.php
+++ b/administrator/components/com_userlogs/helpers/userlogs.php
@@ -19,7 +19,7 @@ class UserlogsHelper
 	/**
 	 * Method to extract data array of objects into CSV file
 	 *
-	 * @param   array  $data  Has the data to be exported
+	 * @param   array $data The logs data to be exported
 	 *
 	 * @return  void
 	 *
@@ -27,9 +27,8 @@ class UserlogsHelper
 	 */
 	public static function dataToCsv($data)
 	{
-		$date = JFactory::getDate();
+		$date     = JFactory::getDate();
 		$filename = "logs_" . $date;
-		$data = json_decode(json_encode($data), true);
 
 		$app = JFactory::getApplication();
 		$app->setHeader('Content-Type', 'application/csv', true)
@@ -45,10 +44,16 @@ class UserlogsHelper
 
 		fputcsv($fp, $headers);
 
-		foreach ($data as $log)
+		foreach ($data as $row)
 		{
-			$app->triggerEvent('onLogMessagePrepare', array (&$log['message'], $log['extension']));
-			$log['ip_address'] = JText::_($log['ip_address']);
+			$log               = array();
+			$log['id']         = $row->id;
+			$log['message']    = $row->message;
+			$log['log_date']   = $row->log_date;
+			$log['extension']  = $row->extension;
+			$log['user_id']    = $row->user_id;
+			$log['ip_address'] = JText::_($row->ip_address);
+			$app->triggerEvent('onLogMessagePrepare', array(&$log['message'], $log['extension']));
 			$log['extension'] = self::translateExtensionName(strtoupper(strtok($log['extension'], '.')));
 
 			fputcsv($fp, $log, ',');
@@ -87,7 +92,7 @@ class UserlogsHelper
 	 *
 	 * @param   string   $context  The context of the content
 	 *
-	 * @return  mixed  An array of parameters, or false on error.
+	 * @return  mixed  An object contain type parameters, or null if not found
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -101,14 +106,7 @@ class UserlogsHelper
 
 		$db->setQuery($query);
 
-		$items = $db->loadObjectList();
-
-		if (empty($items))
-		{
-			return false;
-		}
-
-		return $items[0];
+		return $db->loadObject();
 	}
 
 	/**
@@ -127,6 +125,11 @@ class UserlogsHelper
 	{
 		$items = array();
 		$table = JTable::getInstance($tableType, $tablePrefix);
+
+		if ($table === false)
+		{
+			return $items;
+		}
 
 		foreach ($pks as $pk)
 		{

--- a/administrator/components/com_userlogs/helpers/userlogs.php
+++ b/administrator/components/com_userlogs/helpers/userlogs.php
@@ -44,17 +44,13 @@ class UserlogsHelper
 
 		fputcsv($fp, $headers);
 
-		foreach ($data as $row)
+		foreach ($data as $log)
 		{
-			$log               = array();
-			$log['id']         = $row->id;
-			$log['message']    = $row->message;
-			$log['log_date']   = $row->log_date;
-			$log['extension']  = $row->extension;
-			$log['user_id']    = $row->user_id;
-			$log['ip_address'] = JText::_($row->ip_address);
+			$log               = (array) $log;
+			$log['ip_address'] = JText::_($log['ip_address']);
+			$log['extension']  = self::translateExtensionName(strtoupper(strtok($log['extension'], '.')));
+
 			$app->triggerEvent('onLogMessagePrepare', array(&$log['message'], $log['extension']));
-			$log['extension'] = self::translateExtensionName(strtoupper(strtok($log['extension'], '.')));
 
 			fputcsv($fp, $log, ',');
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes several clean up to UserlogsHelper class

1. The code **$data = json_decode(json_encode($data), true);** in dataToCsv method looks strange to me.  End code data in json, then decode it immediately to get return data in array could cause performance issue (just guess). I removed that code and add some code to build csv data in for loop block

2. Use $db->loadObject instead of $db->loadObjectList() in getLogMessageParams

3. Added a check to prevent fatal error when $table class not found in getDataByPks method




