### PR TITLE
Move delete logs process to system plugin

### DIFF
--- a/administrator/components/com_userlogs/models/userlogs.php
+++ b/administrator/components/com_userlogs/models/userlogs.php
@@ -74,8 +74,6 @@ class UserlogsModelUserlogs extends JModelList
 	 */
 	protected function getListQuery()
 	{
-		$this->checkIn();
-
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true)
 				->select('a.*')
@@ -136,45 +134,6 @@ class UserlogsModelUserlogs extends JModelList
 		}
 
 		return $query;
-	}
-
-	/**
-	 * Check for old logs that needs to be deleted_comment
-	 *
-	 * @return void
-	 *
-	 * @since __DEPLOY_VERSION__
-	 */
-	protected function checkIn()
-	{
-		$plugin = JPluginHelper::getPlugin('system', 'userlogs');
-
-		if (!empty($plugin))
-		{
-			$pluginParams = new Registry($plugin->params);
-			$daysToDeleteAfter = (int) $pluginParams->get('logDeletePeriod', 0);
-
-			if ($daysToDeleteAfter > 0)
-			{
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true);
-				$conditions = array($db->quoteName('log_date') . ' < DATE_SUB(NOW(), INTERVAL ' . $daysToDeleteAfter . ' DAY)');
-
-				$query->delete($db->quoteName('#__user_logs'))->where($conditions);
-				$db->setQuery($query);
-
-				try
-				{
-					$db->execute();
-				}
-				catch (RuntimeException $e)
-				{
-					JError::raiseWarning(500, $db->getMessage());
-
-					return false;
-				}
-			}
-		}
 	}
 
 	/**

--- a/plugins/system/userlogs/userlogs.php
+++ b/plugins/system/userlogs/userlogs.php
@@ -819,4 +819,145 @@ class PlgSystemUserLogs extends JPlugin
 			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
 		}
 	}
+
+	/**
+	 * Runs after the HTTP response has been sent to the client and delete log records older than certain days
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onAfterRender()
+	{
+		$daysToDeleteAfter = (int) $this->params->get('logDeletePeriod', 0);
+
+		if ($daysToDeleteAfter <= 0)
+		{
+			return;
+		}
+
+		$deleteFrequency = 3600 * 24; // The delete frequency will be once per day
+
+		// Do we need to run? Compare the last run timestamp stored in the plugin's options with the current
+		// timestamp. If the difference is greater than the cache timeout we shall not execute again.
+		$now  = time();
+		$last = (int) $this->params->get('lastrun', 0);
+
+		if (abs($now - $last) < $deleteFrequency)
+		{
+			return;
+		}
+
+		// Update last run status
+		// If I have the time of the last run, I can update, otherwise insert
+		$this->params->set('lastrun', $now);
+
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->update($db->qn('#__extensions'))
+			->set($db->qn('params') . ' = ' . $db->q($this->params->toString('JSON')))
+			->where($db->qn('type') . ' = ' . $db->q('plugin'))
+			->where($db->qn('folder') . ' = ' . $db->q('system'))
+			->where($db->qn('element') . ' = ' . $db->q('userlogs'));
+
+		try
+		{
+			// Lock the tables to prevent multiple plugin executions causing a race condition
+			$db->lockTable('#__extensions');
+		}
+		catch (Exception $e)
+		{
+			// If we can't lock the tables it's too risky to continue execution
+			return;
+		}
+
+		try
+		{
+			// Update the plugin parameters
+			$result = $db->setQuery($query)->execute();
+
+			$this->clearCacheGroups(array('com_plugins'), array(0, 1));
+		}
+		catch (Exception $exc)
+		{
+			// If we failed to execite
+			$db->unlockTables();
+			$result = false;
+		}
+
+		try
+		{
+			// Unlock the tables after writing
+			$db->unlockTables();
+		}
+		catch (Exception $e)
+		{
+			// If we can't lock the tables assume we have somehow failed
+			$result = false;
+		}
+
+		// Abort on failure
+		if (!$result)
+		{
+			return;
+		}
+
+		$daysToDeleteAfter = (int) $this->params->get('logDeletePeriod', 0);
+
+		if ($daysToDeleteAfter > 0)
+		{
+			$conditions = array($db->quoteName('log_date') . ' < DATE_SUB(NOW(), INTERVAL ' . $daysToDeleteAfter . ' DAY)');
+
+			$query->clear()
+				->delete($db->quoteName('#__user_logs'))->where($conditions);
+			$db->setQuery($query);
+
+			try
+			{
+				$db->execute();
+			}
+			catch (RuntimeException $e)
+			{
+				// Ignore it
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Clears cache groups. We use it to clear the plugins cache after we update the last run timestamp.
+	 *
+	 * @param   array  $clearGroups   The cache groups to clean
+	 * @param   array  $cacheClients  The cache clients (site, admin) to clean
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function clearCacheGroups(array $clearGroups, array $cacheClients = array(0, 1))
+	{
+		$conf = JFactory::getConfig();
+
+		foreach ($clearGroups as $group)
+		{
+			foreach ($cacheClients as $client_id)
+			{
+				try
+				{
+					$options = array(
+						'defaultgroup' => $group,
+						'cachebase'    => $client_id ? JPATH_ADMINISTRATOR . '/cache' :
+							$conf->get('cache_path', JPATH_SITE . '/cache')
+					);
+
+					$cache = JCache::getInstance('callback', $options);
+					$cache->clean();
+				}
+				catch (Exception $e)
+				{
+					// Ignore it
+				}
+			}
+		}
+	}
 }

--- a/plugins/system/userlogs/userlogs.php
+++ b/plugins/system/userlogs/userlogs.php
@@ -827,7 +827,7 @@ class PlgSystemUserLogs extends JPlugin
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function onAfterRender()
+	public function onAfterRespond()
 	{
 		$daysToDeleteAfter = (int) $this->params->get('logDeletePeriod', 0);
 

--- a/plugins/system/userlogs/userlogs.xml
+++ b/plugins/system/userlogs/userlogs.xml
@@ -44,6 +44,12 @@
 					multiple="true"
 					default="com_banners,com_cache,com_categories,com_config,com_contact,com_content,com_installer,com_media,com_menus,com_messages,com_modules,com_newsfeeds,com_plugins,com_redirect,com_tags,com_templates,com_users"
 				/>
+				<field
+						name="lastrun"
+						type="hidden"
+						default="0"
+						size="15"
+				/>
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
As mentioned, I don't think delete old log records on display process is correct. So in this PR, I move that delete process to the system plugin

Currently, it is hard coded to be run once per day (this logic is borrowed from update notification plugin). Maybe we should introduce a new parameter for configuring it? If Yes, could you recommend the title for that parameter (like Delete Frequency)?

