### PR TITLE
Improvements

### DIFF
--- a/administrator/components/com_userlogs/helpers/userlogs.php
+++ b/administrator/components/com_userlogs/helpers/userlogs.php
@@ -19,7 +19,7 @@ class UserlogsHelper
 	/**
 	 * Method to extract data array of objects into CSV file
 	 *
-	 * @param   array $data The logs data to be exported
+	 * @param   array  $data  The logs data to be exported
 	 *
 	 * @return  void
 	 *
@@ -86,13 +86,13 @@ class UserlogsHelper
 	/**
 	 * Get parameters to be
 	 *
-	 * @param   string   $context  The context of the content
+	 * @param   string  $context  The context of the content
 	 *
-	 * @return  mixed  An object contain type parameters, or null if not found
+	 * @return  mixed  An object contains content type parameters, or null if not found
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function getLogMessageParams($context)
+	public static function getLogContentTypeParams($context)
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
@@ -108,33 +108,59 @@ class UserlogsHelper
 	/**
 	 * Method to retrieve data by primary keys from a table
 	 *
-	 * @param   array   $pks          An array of primary key ids of the content that has changed state.
-	 * @param   string  $field        The field to get from the table
-	 * @param   string  $tableType    The type (name) of the JTable class to get an instance of.
-	 * @param   string  $tablePrefix  An optional prefix for the table class name.
+	 * @param   array   $pks      An array of primary key ids of the content that has changed state.
+	 * @param   string  $field    The field to get from the table
+	 * @param   string  $idField  The primary key of the table
+	 * @param   string  $table    The database table to get data from
 	 *
 	 * @return  array
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function getDataByPks($pks, $field, $tableType, $tablePrefix = 'JTable')
+	public static function getDataByPks($pks, $field, $idField, $table)
 	{
-		$items = array();
-		$table = JTable::getInstance($tableType, $tablePrefix);
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select($db->quoteName(array($idField, $field)))
+			->from($db->quoteName($table))
+			->where($db->quoteName($idField) . ' IN (' . implode(',', $pks) . ')');
+		$db->setQuery($query);
 
-		if ($table === false)
+		try
 		{
-			return $items;
+			return $db->loadObjectList($idField);
+		}
+		catch (RuntimeException $e)
+		{
+			return array();
+		}
+	}
+
+	/**
+	 * Get human readable log message for a User Action Log
+	 *
+	 * @param   stdClass  $log  A User Action log message record
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getHumanReadableLogMessage($log)
+	{
+		$message = JText::_($log->message_language_key);
+		$messageData = json_decode($log->message, true);
+
+		// Special handling for translation extension name
+		if (isset($messageData['extension_name']))
+		{
+			$messageData['extension_name'] = self::translateExtensionName($messageData['extension_name']);
 		}
 
-		foreach ($pks as $pk)
+		foreach ($messageData as $key => $value)
 		{
-			if ($table->load($pk))
-			{
-				$items[] = $table->get($field);
-			}
+			$message = str_replace('{'.$key.'}', $value, $message);
 		}
 
-		return $items;
+		return $message;
 	}
 }

--- a/administrator/components/com_userlogs/views/userlogs/tmpl/default.php
+++ b/administrator/components/com_userlogs/views/userlogs/tmpl/default.php
@@ -93,7 +93,7 @@ JFactory::getDocument()->addScriptDeclaration('
 								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 							</td>
 							<td>								
-								<?php echo $this->escape($item->message); ?>
+								<?php echo UserlogsHelper::getHumanReadableLogMessage($item); ?>
 							</td>
 							<td>
 								<?php echo UserlogsHelper::translateExtensionName(strtoupper(strtok($this->escape($item->extension), '.'))); ?>

--- a/administrator/components/com_userlogs/views/userlogs/view.html.php
+++ b/administrator/components/com_userlogs/views/userlogs/view.html.php
@@ -78,16 +78,6 @@ class UserlogsViewUserlogs extends JViewLegacy
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->pagination    = $this->get('Pagination');
 
-		if (!empty($this->items))
-		{
-			$app = JFactory::getApplication();
-
-			foreach ($this->items as $item)
-			{
-				$app->triggerEvent('onLogMessagePrepare', array (&$item->message, $item->extension));
-			}
-		}
-
 		if (count($errors = $this->get('Errors')))
 		{
 			JError::raiseError(500, implode("\n", $errors));

--- a/administrator/language/en-GB/en-GB.plg_system_userlogs.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_userlogs.ini
@@ -17,43 +17,39 @@ PLG_SYSTEM_USERLOGS_LOG_EXTENSIONS="Select events to be logged"
 PLG_SYSTEM_USERLOGS_LOG_EXTENSIONS_DESC="Select events to be logged"
 PLG_SYSTEM_USERLOGS_NOTIFICATIONS="Send notifications for User Actions Log"
 PLG_SYSTEM_USERLOGS_NOTIFICATIONS_DESC="Send a notifications of users' actions log to your email"
-PLG_SYSTEM_USERLOGS_ON_CONTENT_AFTER_DELETE_MESSAGE="%s deleted"
-PLG_SYSTEM_USERLOGS_ON_CONTENT_AFTER_SAVE_MESSAGE="%s edited"
-PLG_SYSTEM_USERLOGS_ON_CONTENT_AFTER_SAVE_NEW_MESSAGE="New %s created"
-PLG_SYSTEM_USERLOGS_ON_CONTENT_CHANGE_STATE_ARCHIVED_MESSAGE="[%s] - archived"
-PLG_SYSTEM_USERLOGS_ON_CONTENT_CHANGE_STATE_PUBLISHED_MESSAGE="[%s] - published"
-PLG_SYSTEM_USERLOGS_ON_CONTENT_CHANGE_STATE_TRASHED_MESSAGE="[%s] - trashed"
-PLG_SYSTEM_USERLOGS_ON_CONTENT_CHANGE_STATE_UNPUBLISHED_MESSAGE="[%s] - unpublished"
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_DELETE_MESSAGE="%s deleted"
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_INSTALL_MESSAGE="Extension installed, its name is "%s""
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_SAVE_NEW_MESSAGE="New %s created"
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_SAVE_MESSAGE="%s edited"
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_SAVE_NEW_MESSAGE="New %s created"
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_SAVE_MESSAGE="%s edited"
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_UNINSTALL_MESSAGE="Extension uninstalled, its name is "%s""
-PLG_SYSTEM_USERLOGS_ON_EXTENSION_AFTER_UPDATE_MESSAGE="Extension deleted, its id=\"%s\""
-PLG_SYSTEM_USERLOGS_ON_USER_AFTER_DELETE_GROUP_MESSAGE="Users group \"%s\" deleted"
-PLG_SYSTEM_USERLOGS_ON_USER_AFTER_DELETE_MESSAGE="User \"%s\" deleted"
-PLG_SYSTEM_USERLOGS_ON_USER_AFTER_SAVE_GROUP_MESSAGE="Users group \"%s\" edited"
-PLG_SYSTEM_USERLOGS_ON_USER_AFTER_SAVE_GROUP_NEW_MESSAGE="Users group \"%s\" created"
-PLG_SYSTEM_USERLOGS_ON_USER_AFTER_SAVE_MESSAGE="User \"%s\" data edited"
-PLG_SYSTEM_USERLOGS_ON_USER_AFTER_SAVE_NEW_MESSAGE="New user created called \"%s\""
-PLG_SYSTEM_USERLOGS_TITLED=", its title is \"%s\""
-PLG_SYSTEM_USERLOGS_TYPE_ACCESS_LEVEL="access level"
-PLG_SYSTEM_USERLOGS_TYPE_ARTICLE="article"
-PLG_SYSTEM_USERLOGS_TYPE_BANNER="banner"
-PLG_SYSTEM_USERLOGS_TYPE_BANNER_CLIENT="banner client"
-PLG_SYSTEM_USERLOGS_TYPE_CATEGORY="category"
-PLG_SYSTEM_USERLOGS_TYPE_COMPONENT_CONFIG="Component Configuration"
-PLG_SYSTEM_USERLOGS_TYPE_CONTACT="contact"
-PLG_SYSTEM_USERLOGS_TYPE_LINK="link redirect"
-PLG_SYSTEM_USERLOGS_TYPE_LINK_REDIRECT="link redirect"
-PLG_SYSTEM_USERLOGS_TYPE_MEDIA="media"
-PLG_SYSTEM_USERLOGS_TYPE_MENU="menu"
-PLG_SYSTEM_USERLOGS_TYPE_MENU_ITEM="menu item"
-PLG_SYSTEM_USERLOGS_TYPE_MODULE="module"
-PLG_SYSTEM_USERLOGS_TYPE_NEWSFEED="newsfeed"
-PLG_SYSTEM_USERLOGS_TYPE_PLUGIN="plugin"
-PLG_SYSTEM_USERLOGS_TYPE_TAG="tag"
-PLG_SYSTEM_USERLOGS_TYPE_USER_NOTE="user note"
 PLG_SYSTEM_USERLOGS_XML_DESCRIPTION="Record the actions of users on the site so they can be reviewed if required."
+; Articles
+PLG_SYSTEM_USERLOGS_ARTICLE_ADDED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> added new article <a href="_QQ_"index.php?option=com_content&task=article.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_ARTICLE_UPDATED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> updated the article <a href="_QQ_"index.php?option=com_content&task=article.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_ARTICLE_PUBLISHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> published the article <a href="_QQ_"index.php?option=com_content&task=article.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_ARTICLE_UNPUBLISHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> unpublished the article <a href="_QQ_"index.php?option=com_content&task=article.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_ARTICLE_TRASHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> trashed the article <a href="_QQ_"index.php?option=com_content&task=article.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_ARTICLE_DELETED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> deleted the article {title}"
+; Banners
+; Banner Clinets
+; Categories
+; Contacts
+; Link Redirects
+; Media? Need to find out what data to logged
+; Menus
+; Menu Items
+; Newsfeeds
+; Tags
+; User Notes
+; Modules
+PLG_SYSTEM_USERLOGS_MODULE_ADDED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> added new module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_UPDATED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> updated the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_UNPUBLISHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> unpublished the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_PUBLISHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> published the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_TRASHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> trasked the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_DELETED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> deleted the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_INSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> installed the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{extension_name}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_UNINSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> uninstalled the module {extension_name}"
+; Plugins
+PLG_SYSTEM_USERLOGS_PLUGIN_UPDATED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> updated the plugin <a href="_QQ_"index.php?option=com_plugins&task=plugin.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_PLUGIN_INSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> installed the plugin <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{extension_name}</a>"
+PLG_SYSTEM_USERLOGS_PLUGIN_UNINSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> uninstalled the plugin {extension_name}"
+; Component
+PLG_SYSTEM_USERLOGS_COMPONENT_CONFIG_UPDATED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> change settings of the component {extension_name}"
+PLG_SYSTEM_USERLOGS_COMPONENT_INSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> installed the component {extension_name}"
+PLG_SYSTEM_USERLOGS_COMPONENT_UNINSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> uninstalled the component {extension_name}"

--- a/administrator/language/en-GB/en-GB.plg_system_userlogs.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_userlogs.ini
@@ -42,12 +42,12 @@ PLG_SYSTEM_USERLOGS_MODULE_UPDATED="User <a href="_QQ_"index.php?option=com_user
 PLG_SYSTEM_USERLOGS_MODULE_UNPUBLISHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> unpublished the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
 PLG_SYSTEM_USERLOGS_MODULE_PUBLISHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> published the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
 PLG_SYSTEM_USERLOGS_MODULE_TRASHED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> trasked the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
-PLG_SYSTEM_USERLOGS_MODULE_DELETED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> deleted the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_MODULE_DELETED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> deleted the module {title}</a>"
 PLG_SYSTEM_USERLOGS_MODULE_INSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> installed the module <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{extension_name}</a>"
 PLG_SYSTEM_USERLOGS_MODULE_UNINSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> uninstalled the module {extension_name}"
 ; Plugins
-PLG_SYSTEM_USERLOGS_PLUGIN_UPDATED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> updated the plugin <a href="_QQ_"index.php?option=com_plugins&task=plugin.edit&id={id}"_QQ_">{title}</a>"
-PLG_SYSTEM_USERLOGS_PLUGIN_INSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> installed the plugin <a href="_QQ_"index.php?option=com_modules&task=module.edit&id={id}"_QQ_">{extension_name}</a>"
+PLG_SYSTEM_USERLOGS_PLUGIN_UPDATED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> updated the plugin <a href="_QQ_"index.php?option=com_plugins&task=plugin.edit&extension_id={id}"_QQ_">{title}</a>"
+PLG_SYSTEM_USERLOGS_PLUGIN_INSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> installed the plugin <a href="_QQ_"index.php?option=com_plugins&task=plugin.edit&extension_id={id}"_QQ_">{extension_name}</a>"
 PLG_SYSTEM_USERLOGS_PLUGIN_UNINSTALLED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> uninstalled the plugin {extension_name}"
 ; Component
 PLG_SYSTEM_USERLOGS_COMPONENT_CONFIG_UPDATED="User <a href="_QQ_"index.php?option=com_users&task=user.edit&id={userId}"_QQ_">{username}</a> change settings of the component {extension_name}"

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -2094,6 +2094,7 @@ CREATE TABLE IF NOT EXISTS `#__user_usergroup_map` (
 
 CREATE TABLE IF NOT EXISTS `#__user_logs` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `message_language_key` varchar(255) NOT NULL DEFAULT '',
   `message` text NOT NULL,
   `log_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `extension` varchar(50) NOT NULL DEFAULT '',
@@ -2139,30 +2140,32 @@ CREATE TABLE IF NOT EXISTS `#__user_logs_tables_data` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `type_title` varchar(255) NOT NULL DEFAULT '',
   `type_alias` varchar(255) NOT NULL DEFAULT '',
+  `id_holder` varchar(255),
   `title_holder` varchar(255),
-  `table_values` varchar(255),
+  `table_name` varchar(255),
+  `text_prefix` varchar(255),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
-INSERT INTO `#__user_logs_tables_data` (`id`, `type_title`, `type_alias`, `title_holder`, `table_values`) VALUES
-(1, 'article', 'com_content.article', 'title' ,'{"table_type":"Content","table_prefix":"JTable"}'),
-(2, 'article', 'com_content.form', 'title' ,'{"table_type":"Content","table_prefix":"JTable"}'),
-(3, 'banner', 'com_banners.banner', 'name' ,'{"table_type":"Banner","table_prefix":"BannersTable"}'),
-(4, 'user_note', 'com_users.note', 'subject' ,'{"table_type":"Note","table_prefix":"UsersTable"}'),
-(5, 'media', 'com_media.file', 'name' ,'{"table_type":"","table_prefix":""}'),
-(6, 'category', 'com_categories.category', 'title' ,'{"table_type":"Category","table_prefix":"JTable"}'),
-(7, 'menu', 'com_menus.menu', 'title' ,'{"table_type":"Menu","table_prefix":"JTable"}'),
-(8, 'menu_item', 'com_menus.item', 'title' ,'{"table_type":"Menu","table_prefix":"JTable"}'),
-(9, 'newsfeed', 'com_newsfeeds.newsfeed', 'name' ,'{"table_type":"Newsfeed","table_prefix":"NewsfeedsTable"}'),
-(10, 'link', 'com_redirect.link', 'old_url' ,'{"table_type":"Link","table_prefix":"RedirectTable"}'),
-(11, 'tag', 'com_tags.tag', 'title' ,'{"table_type":"Tag","table_prefix":"TagsTable"}'),
-(12, 'style', 'com_templates.style', 'title' ,'{"table_type":"","table_prefix":""}'),
-(13, 'plugin', 'com_plugins.plugin', 'name' ,'{"table_type":"Extension","table_prefix":"JTable"}'),
-(14, 'component_config', 'com_config.component', 'name', '{"table_type":"","table_prefix":""}'),
-(15, 'contact', 'com_contact.contact', 'name', '{"table_type":"Contact","table_prefix":"ContactTable"}'),
-(16, 'module', 'com_modules.module', 'title', '{"table_type":"Module","table_prefix":"JTable"}'),
-(17, 'access_level', 'com_users.level', 'title', '{"table_type":"Viewlevel","table_prefix":"JTable"}'),
-(18, 'banner_client', 'com_banners.client', 'name', '{"table_type":"Client","table_prefix":"BannersTable"}');
+INSERT INTO `#__user_logs_tables_data` (`id`, `type_title`, `type_alias`, `id_holder`, `title_holder`, `table_name`, `text_prefix`) VALUES
+(1, 'article', 'com_content.article', 'id' ,'title' , '#__content', 'PLG_SYSTEM_USERLOGS'),
+(2, 'article', 'com_content.form', 'id', 'title' , '#__content', 'PLG_SYSTEM_USERLOGS'),
+(3, 'banner', 'com_banners.banner', 'id' ,'name' , '#__banners', 'PLG_SYSTEM_USERLOGS'),
+(4, 'user_note', 'com_users.note', 'id', 'subject' ,'#__user_notes', 'PLG_SYSTEM_USERLOGS'),
+(5, 'media', 'com_media.file', '' , 'name' , '',  'PLG_SYSTEM_USERLOGS'),
+(6, 'category', 'com_categories.category', 'id' , 'title' , '#__categories', 'PLG_SYSTEM_USERLOGS'),
+(7, 'menu', 'com_menus.menu', 'id' ,'title' , '#__menu_types', 'PLG_SYSTEM_USERLOGS'),
+(8, 'menu_item', 'com_menus.item', 'id' , 'title' , '#__menu', 'PLG_SYSTEM_USERLOGS'),
+(9, 'newsfeed', 'com_newsfeeds.newsfeed', 'id' ,'name' , '#__newsfeeds', 'PLG_SYSTEM_USERLOGS'),
+(10, 'link', 'com_redirect.link', 'id', 'old_url' , '__redirect_links', 'PLG_SYSTEM_USERLOGS'),
+(11, 'tag', 'com_tags.tag', 'id', 'title' , '#__tags', 'PLG_SYSTEM_USERLOGS'),
+(12, 'style', 'com_templates.style', 'id' , 'title' , '#__template_styles', 'PLG_SYSTEM_USERLOGS'),
+(13, 'plugin', 'com_plugins.plugin', 'id' , 'name' , '#__extensions', 'PLG_SYSTEM_USERLOGS'),
+(14, 'component_config', 'com_config.component', 'extension_id' , 'name', '', 'PLG_SYSTEM_USERLOGS'),
+(15, 'contact', 'com_contact.contact', 'id', 'name', '#__contact_details', 'PLG_SYSTEM_USERLOGS'),
+(16, 'module', 'com_modules.module', 'id' ,'title', '#__modules', 'PLG_SYSTEM_USERLOGS'),
+(17, 'access_level', 'com_users.level', 'id' , 'title', '#__viewlevels', 'PLG_SYSTEM_USERLOGS'),
+(18, 'banner_client', 'com_banners.client', 'id', 'name', '#__banner_clients', 'PLG_SYSTEM_USERLOGS');
  
 --
 -- Table structure for table `#__utf8_conversion`

--- a/plugins/system/userlogs/layouts/logstable.php
+++ b/plugins/system/userlogs/layouts/logstable.php
@@ -14,6 +14,8 @@ $source = JPATH_ADMINISTRATOR . '/components/' . 'com_userlogs';
 
 $lang->load("com_userlogs", JPATH_ADMINISTRATOR, null, false, true)
 	|| $lang->load("com_userlogs", $source, null, false, true);
+
+$messages = $displayData['messages'];
 ?>
 <h1>
 	<?php echo JText::_('PLG_SYSTEM_USERLOGS_EMAIL_SUBJECT'); ?>
@@ -30,12 +32,19 @@ $lang->load("com_userlogs", JPATH_ADMINISTRATOR, null, false, true)
 		<th><?php echo JText::_('COM_USERLOGS_IP_ADDRESS'); ?></th>
 	</thead>
 	<tbody>
-		<tr>
-			<td><?php echo $displayData['message']; ?></td>
-			<td><?php echo $displayData['log_date']; ?></td>
-			<td><?php echo $displayData['extension']; ?></td>
-			<td><?php echo $displayData['username']; ?></td>
-			<td><?php echo $displayData['ip']; ?></td>
-		</tr>
+        <?php
+            foreach ($messages as $message)
+            {
+            ?>
+                <tr>
+                    <td><?php echo $message->message; ?></td>
+                    <td><?php echo $message->log_date; ?></td>
+                    <td><?php echo $message->extension; ?></td>
+                    <td><?php echo $displayData['username']; ?></td>
+                    <td><?php echo $message->ip_address; ?></td>
+                </tr>
+            <?php
+            }
+        ?>
 	</tbody>
 </table>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes massive changes to current User Action logs code base. It contains following improvements:
- Added link to the user account performs the action and link to the item being changed by the action
- Store action related data in better format so that it can be used to generate the log message.
- Move the code which translates the json-encoded message to human readable message to a helper method instead of in a plugin trigger like before.
- Addressed an issue with the current implement: When we change state of multiple items, multiple records will be logged(each record for one item) but only one email sent.

There are still work left to get this PR completed, however, I want to submit it here to see whether we want to go with this direction or not before working further on it

- Update installation SQL 
- Update update SQL
- Added missing language items for other content types

![action_logs](https://user-images.githubusercontent.com/977664/39986285-70e4216c-578b-11e8-8ecb-c23e6275c149.png)

As this makes change to SQL, if someone wants to play with it, please get and install a copy of my branch https://github.com/joomdonation/privacy-framework/archive/improvements.zip