### PR TITLE
Privacy quick icon clean up

### DIFF
--- a/administrator/components/com_privacy/controller.php
+++ b/administrator/components/com_privacy/controller.php
@@ -50,29 +50,30 @@ class PrivacyController extends JControllerLegacy
 	}
 
 	/**
-	 * Fetch and report privacy requests in JSON format, for AJAX requests
+	 * Fetch and report number urgent privacy requests in JSON format, for AJAX requests
 	 *
 	 * @return void
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function ajax()
+	public function get_number_urgent_requests()
 	{
 		$app = Factory::getApplication();
 
 		// Check for a valid token. If invalid, send a 403 with the error message.
 		if (!Session::checkToken('get'))
 		{
-			$response = new JsonResponse(new \Exception(Text::_('JINVALID_TOKEN'), 403));
+			$app->setHeader('status', 403, true);
 			$app->sendHeaders();
-			echo json_encode($response);
+			echo JText::_('JINVALID_TOKEN');
 			$app->close();
 		}
 
 		/** @var PrivacyModelRequests $model */
-		$model    = $this->getModel('requests');	
-		$requests = $model->getOlder();
-		echo json_encode($requests);
+		$model                = $this->getModel('requests');
+		$numberUrgentRequests = $model->getNumberUrgentRequests();
+
+		echo new JResponseJson(array('number_urgent_requests' => $numberUrgentRequests));
 
 		$app->close();
 	}	

--- a/administrator/components/com_privacy/controller.php
+++ b/administrator/components/com_privacy/controller.php
@@ -56,7 +56,7 @@ class PrivacyController extends JControllerLegacy
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function get_number_urgent_requests()
+	public function getNumberUrgentRequests()
 	{
 		$app = Factory::getApplication();
 
@@ -65,7 +65,7 @@ class PrivacyController extends JControllerLegacy
 		{
 			$app->setHeader('status', 403, true);
 			$app->sendHeaders();
-			echo JText::_('JINVALID_TOKEN');
+			echo new JsonResponse(new \Exception(Text::_('JINVALID_TOKEN'), 403));
 			$app->close();
 		}
 

--- a/administrator/components/com_privacy/models/requests.php
+++ b/administrator/components/com_privacy/models/requests.php
@@ -173,43 +173,28 @@ class PrivacyModelRequests extends JModelList
 	}
 
 	/**
-	 * Method to return older privacy requests.
+	 * Method to return number privacy requests older than X days.
 	 *
-	 * @return  array
+	 * @return  int
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getOlder()
+	public function getNumberUrgentRequests()
 	{
-
 		// Load the parameters.
 		$params = ComponentHelper::getComponent('com_privacy')->getParams();
 		$notify = (int) $params->get('notify', 14);
-		$items  = array();
 		$now    = JFactory::getDate()->toSql();
 		$period = '-' . $notify;
 
-		// Create a new query object.
 		$db    = $this->getDbo();
-		$query = $db->getQuery(true);
-		$query->select('COUNT(*)');
+		$query = $db->getQuery(true)
+			->select('COUNT(*)');
 		$query->from($db->quoteName('#__privacy_requests'));
 		$query->where($db->quoteName('status') . ' = 1 ');
 		$query->where($query->dateAdd($now, $period, 'DAY') . ' > ' . $db->quoteName('requested_at'));
 		$db->setQuery($query);
-		
-		$count = $db->loadRow();
 
-		if (!$count['0'] > 0)
-		{
-			return array();
-		}
-
-		for ($i=0; $i < $count['0']; $i++) 
-		{ 
-			$items[] = $count['0'];
-		}
-
-		return $items;
+		return (int) $db->loadResult();
 	}
 }

--- a/media/plg_quickicon_privacycheck/js/privacycheck.js
+++ b/media/plg_quickicon_privacycheck/js/privacycheck.js
@@ -19,33 +19,28 @@ jQuery(document).ready(function() {
 				link.html(plg_quickicon_privacycheck_text.ERROR);
 			}
 
-			if (requestList instanceof Array) {
-				if (requestList.length == 0) {
-					// No requests
-					link.html(plg_quickicon_privacycheck_text.NOREQUEST);
-				} else {
-					// Requests
-					var msgString = '<span class="label label-important">'
-						+ requestList.length + '</span>&nbsp;'
-						+ plg_quickicon_privacycheck_text.REQUESTFOUND_MESSAGE;
-					
-					jQuery('#system-message-container').prepend(
-						'<div class="alert alert-error alert-joomlaupdate">'
-						+ msgString
-						+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_privacycheck_url + '\'">'
-						+ plg_quickicon_privacycheck_text.REQUESTFOUND_BUTTON + '</button>'
-						+ '</div>'
-					);
-					
-					var msgString = plg_quickicon_privacycheck_text.REQUESTFOUND
-						+ '&nbsp;<span class="label label-important">'
-						+ requestList.length + '</span>'
-					
-					link.html(msgString);
-				}
+			if (requestList.data.number_urgent_requests == 0) {
+				// No requests
+				link.html(plg_quickicon_privacycheck_text.NOREQUEST);
 			} else {
-				// An error occurred
-				link.html(plg_quickicon_privacycheck_text.ERROR);
+				// Requests
+				var msgString = '<span class="label label-important">'
+					+ requestList.data.number_urgent_requests + '</span>&nbsp;'
+					+ plg_quickicon_privacycheck_text.REQUESTFOUND_MESSAGE;
+
+				jQuery('#system-message-container').prepend(
+					'<div class="alert alert-error alert-joomlaupdate">'
+					+ msgString
+					+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_privacycheck_url + '\'">'
+					+ plg_quickicon_privacycheck_text.REQUESTFOUND_BUTTON + '</button>'
+					+ '</div>'
+				);
+
+				var msgString = plg_quickicon_privacycheck_text.REQUESTFOUND
+					+ '&nbsp;<span class="label label-important">'
+					+ requestList.data.number_urgent_requests + '</span>'
+
+				link.html(msgString);
 			}
 		},
 		error: function(jqXHR, textStatus, errorThrown) {

--- a/plugins/quickicon/privacycheck/privacycheck.php
+++ b/plugins/quickicon/privacycheck/privacycheck.php
@@ -51,7 +51,7 @@ class PlgQuickiconPrivacyCheck extends JPlugin
 	
 		$options  = array(
 			'plg_quickicon_privacycheck_url'      => Uri::base() . 'index.php?option=com_privacy&view=requests',
-			'plg_quickicon_privacycheck_ajax_url' => Uri::base() . 'index.php?option=com_privacy&task=get_number_urgent_requests&' . $token,
+			'plg_quickicon_privacycheck_ajax_url' => Uri::base() . 'index.php?option=com_privacy&task=getNumberUrgentRequests&' . $token,
 			'plg_quickicon_privacycheck_text'     => array(
 				"NOREQUEST"            => Text::_('PLG_QUICKICON_PRIVACYCHECK_NOREQUEST', true),
 				"REQUESTFOUND"         => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND', true),

--- a/plugins/quickicon/privacycheck/privacycheck.php
+++ b/plugins/quickicon/privacycheck/privacycheck.php
@@ -34,7 +34,7 @@ class PlgQuickiconPrivacyCheck extends JPlugin
 	 *
 	 * @param   string  $context  The calling context
 	 *
-	 * @return  void
+	 * @return  array   A list of icon definition associative arrays
 	 *
 	 * @since   3.9.0
 	 */
@@ -50,8 +50,8 @@ class PlgQuickiconPrivacyCheck extends JPlugin
 		$token    = Session::getFormToken() . '=' . 1;
 	
 		$options  = array(
-			'plg_quickicon_privacycheck_url'      => Uri::base() . 'index.php?option=com_privacy&' . $token,
-			'plg_quickicon_privacycheck_ajax_url' => Uri::base() . 'index.php?option=com_privacy&task=ajax&' . $token,
+			'plg_quickicon_privacycheck_url'      => Uri::base() . 'index.php?option=com_privacy&view=requests',
+			'plg_quickicon_privacycheck_ajax_url' => Uri::base() . 'index.php?option=com_privacy&task=get_number_urgent_requests&' . $token,
 			'plg_quickicon_privacycheck_text'     => array(
 				"NOREQUEST"            => Text::_('PLG_QUICKICON_PRIVACYCHECK_NOREQUEST', true),
 				"REQUESTFOUND"         => Text::_('PLG_QUICKICON_PRIVACYCHECK_REQUESTFOUND', true),
@@ -67,7 +67,7 @@ class PlgQuickiconPrivacyCheck extends JPlugin
 
 		return array(
 			array(
-				'link'  => 'index.php?option=com_privacy&view=requests&' . $token,
+				'link'  => 'index.php?option=com_privacy&view=requests',
 				'image' => 'users',
 				'icon'  => 'header/icon-48-user.png',
 				'text'  => Text::_('PLG_QUICKICON_PRIVACYCHECK_CHECKING'),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes some clean up to privacy quick icon:

1. Change logic of the original getOlder method. The original code looks strange to me, all it needs is return number of requests need admin attention. There was strange lines of code to create an array and it looks wrong to me

2. Use JResponseJson to return the ajax data, thus the javascript code need to be changed, too.

3. Improve the code when token is invalid. The original code doesn't look correct, the new code is copied from com_installer update controller, ajax method 

4. User better method names (unsure if it's better :D).

ajax -> get_number_urgent_requests
older -> getNumberUrgentRequests