### PR TITLE
show the edit profile in the admin users

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_actionlogs.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_actionlogs.ini
@@ -10,6 +10,7 @@ PLG_SYSTEM_ACTIONLOGS_LOG_DELETE_PERIOD="Days to delete logs after"
 PLG_SYSTEM_ACTIONLOGS_LOG_DELETE_PERIOD_DESC="Enter how many days logs should be kept before they are deleted. Enter 0 if you don't want to delete the logs."
 PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS="Send notifications for User Actions Log"
 PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS_DESC="Send a notifications of users' actions log to your email"
+PLG_SYSTEM_ACTIONLOGS_OPTIONS="User Actions Log Options"
 PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Record the actions of users on the site so they can be reviewed if required."
 ; Common content type log messages
 PLG_SYSTEM_ACTIONLOGS_CONTENT_ADDED="User <a href="{accountlink}">{username}</a> added new {type} <a href="{itemlink}">{title}</a>"

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -83,7 +83,14 @@ class PlgSystemActionLogs extends JPlugin
 			'com_users.user',
 		);
 
-		if (!in_array($formName, $allowedFormNames) || !JFactory::getUser()->authorise('core.viewlogs'))
+		$canView = JFactory::getUser()->authorise('core.viewlogs');
+
+		if (isset($data->id))
+		{
+			$canView = JUser::getInstance($data->id)->authorise('core.admin');
+		}
+
+		if (!in_array($formName, $allowedFormNames) || !$canView)
 		{
 			return true;
 		}

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -80,6 +80,7 @@ class PlgSystemActionLogs extends JPlugin
 		$allowedFormNames = array(
 			'com_users.profile',
 			'com_admin.profile',
+			'com_users.user',
 		);
 
 		if (!in_array($formName, $allowedFormNames) || !JFactory::getUser()->authorise('core.viewlogs'))

--- a/plugins/system/actionlogs/forms/actionlogs.xml
+++ b/plugins/system/actionlogs/forms/actionlogs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form>
 	<fields name="params">
-		<fieldset name="settings" addfieldpath="/administrator/components/com_actionlogs/models/fields">
+		<fieldset name="actionlogs" label="PLG_SYSTEM_ACTIONLOGS_OPTIONS" addfieldpath="/administrator/components/com_actionlogs/models/fields">
 			<field
 				name="logs_notification_option"
 				type="radio"


### PR DESCRIPTION
This will add the settings BUT it is shown for all users in the admin. I am assuming because https://github.com/joomla-projects/privacy-framework/blob/dev/privacy/plugins/system/actionlogs/actionlogs.php#L85 is getting the id of the user logged in and not the user being edited