### PR TITLE
Fix open privacy article error

### DIFF
--- a/plugins/system/privacyconsent/field/privacy.php
+++ b/plugins/system/privacyconsent/field/privacy.php
@@ -104,24 +104,9 @@ class JFormFieldprivacy extends JFormFieldRadio
 			$db->setQuery($query);
 			$article = $db->loadObject();
 
-			if (JLanguageAssociations::isEnabled())
-			{
-				$privacyassociated = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $privacyarticle);
-			}
-
-			$current_lang = Factory::getLanguage()->getTag();
-
-			if (isset($privacyassociated) && $current_lang !== $article->language && array_key_exists($current_lang, $privacyassociated))
-			{
-				$url  = ContentHelperRoute::getArticleRoute($privacyassociated[$current_lang]->id, $privacyassociated[$current_lang]->catid);
-				$link = JHtml::_('link', JRoute::_($url . '&tmpl=component&lang=' . $privacyassociated[$current_lang]->language), $text, $attribs);
-			}
-			else
-			{
-				$slug = $article->alias ? ($article->id . ':' . $article->alias) : $article->id;
-				$url  = ContentHelperRoute::getArticleRoute($slug, $article->catid);
-				$link = JHtml::_('link', JRoute::_($url . '&tmpl=component&lang=' . $article->language), $text, $attribs);
-			}
+			$slug = $article->alias ? ($article->id . ':' . $article->alias) : $article->id;
+			$url  = ContentHelperRoute::getArticleRoute($slug, $article->catid);
+			$link = JHtml::_('link', JRoute::_($url . '&tmpl=component&lang=' . $article->language), $text, $attribs);
 		}
 		else
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This is an alternative for https://github.com/joomla-projects/privacy-framework/pull/97. When we have privacy consent plugin enabled, users are asked to accept privacy policy before they can access to any pages on the website. The problem with current code is that it doesn't allow users to access to privacy policy article to see the details before accepting. This PR just fixes that logic

### Testing Instructions
1. Make sure plugin System - Privacy Consent is enabled
2. Login to frontend using an account which has not consented privacy policy yet
3. Before patch, you cannot click on Privacy Policy link to see the article
4. After path, you can click on the Privacy Policy link to see the article
5. I tested it myself on multilingual website with associated article, too. But if you can test it, it would be great.