### PR TITLE
Update privacy.php

### DIFF
--- a/plugins/system/privacyconsent/field/privacy.php
+++ b/plugins/system/privacyconsent/field/privacy.php
@@ -40,7 +40,7 @@ class JFormFieldprivacy extends JFormFieldRadio
 	{
 		$privacynote = !empty($this->element['note']) ? $this->element['note'] : Text::_('PLG_SYSTEM_PRIVACYCONSENT_NOTE_FIELD_DEFAULT');
 
-		echo '<div class="alert alert-info">' . $privacynote . '</div>';
+		echo '<div class="alert alert-info">' . Text::_($privacynote) . '</div>';
 
 		return parent::getInput();
 	}


### PR DESCRIPTION
Add possibility for own JTEXT Key

Pull Request for Issue #192 

### Summary of Changes
Wrapped the Message in JTEXT so the user can define an own string too.


### Testing Instructions
Edit the Privacy Consent Plugin and insert a MY_CONSENT_TEXT string into the message box
Add overrides for your languages

### Expected result
The Registration form shows your translated strings even if you don't use the official string



