### PR TITLE
Adding UTC timezone to filename for export

### DIFF
--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -73,7 +73,7 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 		if (count($data))
 		{
 			$rows = ActionlogsHelper::getCsvData($data);
-			$filename     = "logs_" . JFactory::getDate();
+			$filename     = "logs_" . JFactory::getDate() . 'UTC';
 			$csvDelimiter = ComponentHelper::getComponent('com_actionlogs')->getParams()->get('csv_delimiter', ',');
 
 			$app = JFactory::getApplication();

--- a/administrator/components/com_actionlogs/controllers/actionlogs.php
+++ b/administrator/components/com_actionlogs/controllers/actionlogs.php
@@ -73,7 +73,7 @@ class ActionlogsControllerActionlogs extends JControllerAdmin
 		if (count($data))
 		{
 			$rows = ActionlogsHelper::getCsvData($data);
-			$filename     = "logs_" . JFactory::getDate() . 'UTC';
+			$filename     = 'logs_' . JFactory::getDate()->format('Y-m-d_His') . 'UTC';
 			$csvDelimiter = ComponentHelper::getComponent('com_actionlogs')->getParams()->get('csv_delimiter', ',');
 
 			$app = JFactory::getApplication();


### PR DESCRIPTION
PR for #172 
This is an attempt to make the timezone of the timestamp in the filename of the export of CSV logs apparent.