### PR TITLE
Renaming #__action_logs_tables_data to #__action_log_config

### DIFF
--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -87,7 +87,7 @@ class ActionlogsHelper
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
 			->select('a.*')
-			->from($db->quoteName('#__action_logs_tables_data', 'a'))
+			->from($db->quoteName('#__action_log_config', 'a'))
 			->where($db->quoteName('a.type_alias') . ' = ' . $db->quote($context));
 
 		$db->setQuery($query);

--- a/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-05.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.0-2018-05-05.sql
@@ -50,10 +50,10 @@ INSERT INTO `#__action_logs_extensions` (`id`, `extension`) VALUES
 (17, 'com_users');
 
 --
--- Table structure for table `#__action_logs_tables_data`
+-- Table structure for table `#__action_log_config`
 --
 
-CREATE TABLE IF NOT EXISTS `#__action_logs_tables_data` (
+CREATE TABLE IF NOT EXISTS `#__action_log_config` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `type_title` varchar(255) NOT NULL DEFAULT '',
   `type_alias` varchar(255) NOT NULL DEFAULT '',
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS `#__action_logs_tables_data` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
-INSERT INTO `#__action_logs_tables_data` (`id`, `type_title`, `type_alias`, `id_holder`, `title_holder`, `table_name`, `text_prefix`) VALUES
+INSERT INTO `#__action_log_config` (`id`, `type_title`, `type_alias`, `id_holder`, `title_holder`, `table_name`, `text_prefix`) VALUES
 (1, 'article', 'com_content.article', 'id' ,'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (2, 'article', 'com_content.form', 'id', 'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (3, 'banner', 'com_banners.banner', 'id' ,'name' , '#__banners', 'PLG_ACTIONLOG_JOOMLA'),

--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-05.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-05.sql
@@ -52,9 +52,9 @@ SELECT setval('#__action_logs_extensions_id_seq', 18, false);
 -- --------------------------------------------------------
 
 --
--- Table: #__action_logs_tables_data
+-- Table: #__action_log_config
 --
-CREATE TABLE "#__action_logs_tables_data" (
+CREATE TABLE "#__action_log_config" (
   "id" serial NOT NULL,
   "type_title" varchar(255) NOT NULL DEFAULT '',
   "type_alias" varchar(255) NOT NULL DEFAULT '',
@@ -66,9 +66,9 @@ CREATE TABLE "#__action_logs_tables_data" (
 );
 
 --
--- Dumping data for table #__action_logs_tables_data
+-- Dumping data for table #__action_log_config
 --
-INSERT INTO "#__action_logs_tables_data" ("id", "type_title", "type_alias", "id_holder", "table_name", "text_prefix") VALUES
+INSERT INTO "#__action_log_config" ("id", "type_title", "type_alias", "id_holder", "table_name", "text_prefix") VALUES
 (1, 'article', 'com_content.article', 'id' ,'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (2, 'article', 'com_content.form', 'id', 'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (3, 'banner', 'com_banners.banner', 'id' ,'name' , '#__banners', 'PLG_ACTIONLOG_JOOMLA'),
@@ -89,4 +89,4 @@ INSERT INTO "#__action_logs_tables_data" ("id", "type_title", "type_alias", "id_
 (18, 'banner_client', 'com_banners.client', 'id', 'name', '#__banner_clients', 'PLG_ACTIONLOG_JOOMLA');
 
 
-SELECT setval('#__action_logs_tables_data_id_seq', 18, false);
+SELECT setval('#__action_log_config_id_seq', 18, false);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-05-05.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.9.0-2018-05-05.sql
@@ -73,24 +73,24 @@ UNION ALL
 SELECT 17, 'com_users';
 
 SET IDENTITY_INSERT [#__action_logs_extensions]  OFF;
-/****** Object:  Table [#__action_logs_tables_data] ******/
+/****** Object:  Table [#__action_log_config] ******/
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__action_logs_tables_data](
+CREATE TABLE [#__action_log_config](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[type_title] [nvarchar](255) NOT NULL DEFAULT '',
 	[type_alias] [nvarchar](255) NOT NULL DEFAULT '',
 	[title_holder] [nvarchar](255) NULL,
 	[table_values] [nvarchar](255) NULL
-	CONSTRAINT [PK_#__action_logs_tables_data_id] PRIMARY KEY CLUSTERED
+	CONSTRAINT [PK_#__action_log_config_id] PRIMARY KEY CLUSTERED
  (
  	[id] ASC
  )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
  ) ON [PRIMARY];
 
-SET IDENTITY_INSERT [#__action_logs_tables_data]  ON;
+SET IDENTITY_INSERT [#__action_log_config]  ON;
 
-INSERT INTO [#__action_logs_tables_data] ([id], [type_title], [type_alias], [id_holder], [title_holder], [table_name], [text_prefix])
+INSERT INTO [#__action_log_config] ([id], [type_title], [type_alias], [id_holder], [title_holder], [table_name], [text_prefix])
 SELECT 1, 'article', 'com_content.article', 'id' ,'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'
 UNION ALL
 SELECT 2, 'article', 'com_content.form', 'id', 'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'
@@ -127,4 +127,4 @@ SELECT 17, 'access_level', 'com_users.level', 'id' , 'title', '#__viewlevels', '
 UNION ALL
 SELECT 18, 'banner_client', 'com_banners.client', 'id', 'name', '#__banner_clients', 'PLG_ACTIONLOG_JOOMLA';
 
-SET IDENTITY_INSERT [#__action_logs_tables_data]  OFF;
+SET IDENTITY_INSERT [#__action_log_config]  OFF;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -2189,10 +2189,10 @@ INSERT INTO `#__action_logs_extensions` (`id`, `extension`) VALUES
 (17, 'com_users');
 
 --
--- Table structure for table `#__action_logs_tables_data`
+-- Table structure for table `#__action_log_config`
 --
 
-CREATE TABLE IF NOT EXISTS `#__action_logs_tables_data` (
+CREATE TABLE IF NOT EXISTS `#__action_log_config` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `type_title` varchar(255) NOT NULL DEFAULT '',
   `type_alias` varchar(255) NOT NULL DEFAULT '',
@@ -2203,7 +2203,7 @@ CREATE TABLE IF NOT EXISTS `#__action_logs_tables_data` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
-INSERT INTO `#__action_logs_tables_data` (`id`, `type_title`, `type_alias`, `id_holder`, `title_holder`, `table_name`, `text_prefix`) VALUES
+INSERT INTO `#__action_log_config` (`id`, `type_title`, `type_alias`, `id_holder`, `title_holder`, `table_name`, `text_prefix`) VALUES
 (1, 'article', 'com_content.article', 'id' ,'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (2, 'article', 'com_content.form', 'id', 'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (3, 'banner', 'com_banners.banner', 'id' ,'name' , '#__banners', 'PLG_ACTIONLOG_JOOMLA'),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -2177,9 +2177,9 @@ SELECT setval('#__action_logs_extensions_id_seq', 18, false);
 -- --------------------------------------------------------
 
 --
--- Table: #__action_logs_tables_data
+-- Table: #__action_log_config
 --
-CREATE TABLE "#__action_logs_tables_data" (
+CREATE TABLE "#__action_log_config" (
   "id" serial NOT NULL,
   "type_title" varchar(255) NOT NULL DEFAULT '',
   "type_alias" varchar(255) NOT NULL DEFAULT '',
@@ -2191,9 +2191,9 @@ CREATE TABLE "#__action_logs_tables_data" (
 );
 
 --
--- Dumping data for table #__action_logs_tables_data
+-- Dumping data for table #__action_log_config
 --
-INSERT INTO "#__action_logs_tables_data" ("id", "type_title", "type_alias", "id_holder", "title_holder", "table_name", "text_prefix") VALUES
+INSERT INTO "#__action_log_config" ("id", "type_title", "type_alias", "id_holder", "title_holder", "table_name", "text_prefix") VALUES
 (1, 'article', 'com_content.article', 'id' ,'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (2, 'article', 'com_content.form', 'id', 'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'),
 (3, 'banner', 'com_banners.banner', 'id' ,'name' , '#__banners', 'PLG_ACTIONLOG_JOOMLA'),
@@ -2214,7 +2214,7 @@ INSERT INTO "#__action_logs_tables_data" ("id", "type_title", "type_alias", "id_
 (18, 'banner_client', 'com_banners.client', 'id', 'name', '#__banner_clients', 'PLG_ACTIONLOG_JOOMLA');
 
 
-SELECT setval('#__action_logs_tables_data_id_seq', 18, false);
+SELECT setval('#__action_log_config_id_seq', 18, false);
 
 --
 -- Table structure for table `#__viewlevels`

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -3135,10 +3135,10 @@ UNION ALL
 SELECT 17, 'com_users';
 
 SET IDENTITY_INSERT [#__action_logs_extensions]  OFF;
-/****** Object:  Table [#__action_logs_tables_data] ******/
+/****** Object:  Table [#__action_log_config] ******/
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__action_logs_tables_data](
+CREATE TABLE [#__action_log_config](
 	[id] [int] IDENTITY(1,1) NOT NULL,
 	[type_title] [nvarchar](255) NOT NULL DEFAULT '',
 	[type_alias] [nvarchar](255) NOT NULL DEFAULT '',
@@ -3146,15 +3146,15 @@ CREATE TABLE [#__action_logs_tables_data](
 	[title_holder] [nvarchar](255) NULL,
 	[table_name] [nvarchar](255) NULL,
 	[text_prefix] [nvarchar](255) NULL
-	CONSTRAINT [PK_#__action_logs_tables_data_id] PRIMARY KEY CLUSTERED
+	CONSTRAINT [PK_#__action_log_config_id] PRIMARY KEY CLUSTERED
  (
  	[id] ASC
  )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
  ) ON [PRIMARY];
 
-SET IDENTITY_INSERT [#__action_logs_tables_data]  ON;
+SET IDENTITY_INSERT [#__action_log_config]  ON;
 
-INSERT INTO [#__action_logs_tables_data] ([id], [type_title], [type_alias], [id_holder], [title_holder], [table_name], [text_prefix])
+INSERT INTO [#__action_log_config] ([id], [type_title], [type_alias], [id_holder], [title_holder], [table_name], [text_prefix])
 SELECT 1, 'article', 'com_content.article', 'id' ,'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'
 UNION ALL
 SELECT 2, 'article', 'com_content.form', 'id', 'title' , '#__content', 'PLG_ACTIONLOG_JOOMLA'
@@ -3191,7 +3191,7 @@ SELECT 17, 'access_level', 'com_users.level', 'id' , 'title', '#__viewlevels', '
 UNION ALL
 SELECT 18, 'banner_client', 'com_banners.client', 'id', 'name', '#__banner_clients', 'PLG_ACTIONLOG_JOOMLA';
 
-SET IDENTITY_INSERT [#__action_logs_tables_data]  OFF;
+SET IDENTITY_INSERT [#__action_log_config]  OFF;
 
 --
 -- Table structure for table `#__viewlevels`


### PR DESCRIPTION
This renames #__action_logs_tables_data to #__action_log_config. Hopefully that is a slightly more understandeable table name. Please also notice the singular of the logs, hopefully takeing ahead the renameing of com_actionlogs to the singular version. This is to solve #211