### PR TITLE
Load the right translation files at the right time in the actionlogs

### DIFF
--- a/administrator/components/com_actionlogs/models/actionlog.php
+++ b/administrator/components/com_actionlogs/models/actionlog.php
@@ -136,11 +136,12 @@ class ActionlogsModelActionlog extends JModelLegacy
 		}
 
 		$layout    = new JLayoutFile('components.com_actionlogs.layouts.logstable', JPATH_ADMINISTRATOR);
-		$extension = ActionlogsHelper::translateExtensionName(strtoupper(strtok($context, '.')));
+		$extension = strtok($context, '.');
+		ActionlogsHelper::loadTranslationFiles($extension);
 
 		foreach ($messages as $message)
 		{
-			$message->extension = $extension;
+			$message->extension = JText::_($extension);
 			$message->message   = ActionlogsHelper::getHumanReadableLogMessage($message);
 		}
 

--- a/administrator/components/com_actionlogs/models/fields/extension.php
+++ b/administrator/components/com_actionlogs/models/fields/extension.php
@@ -48,8 +48,9 @@ class JFormFieldExtension extends JFormFieldList
 
 		foreach ($extensions as $extension)
 		{
-			$text = ActionlogsHelper::translateExtensionName(strtoupper(strtok($extension->extension, '.')));
-			$options[] = JHtml::_('select.option', $extension->extension, $text);
+			$extension = strtok($context, '.');
+			ActionlogsHelper::loadTranslationFiles($extension);
+			$options[] = JHtml::_('select.option', $extension->extension, JText::_($extension));
 		}
 
 		return array_merge(parent::getOptions(), $options);

--- a/administrator/components/com_actionlogs/models/fields/logtype.php
+++ b/administrator/components/com_actionlogs/models/fields/logtype.php
@@ -56,7 +56,8 @@ class JFormFieldLogType extends JFormFieldCheckboxes
 
 			$defaults[] = $extension;
 
-			$option = JHtml::_('select.option', $extension->extension, ActionlogsHelper::translateExtensionName($extension->extension));
+			ActionlogsHelper::loadTranslationFiles($extension->extension);
+			$option = JHtml::_('select.option', $extension->extension, JText::_($extension->extension));
 			$options[] = (object) array_merge($tmp, (array) $option);
 		}
 

--- a/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
+++ b/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
@@ -63,8 +63,8 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 				</tfoot>
 				<tbody>
 					<?php foreach ($this->items as $i => $item) :
-						// Translate extension name here to load translation files before translating message
-						$extensionName = ActionlogsHelper::translateExtensionName(strtok($item->extension, '.')); ?>
+						$extension = strtok($item->extension, '.');
+						ActionlogsHelper::loadTranslationFiles($extension); ?>
 						<tr class="row<?php echo $i % 2; ?>">
 							<td class="center">
 								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
@@ -73,7 +73,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 								<?php echo ActionlogsHelper::getHumanReadableLogMessage($item); ?>
 							</td>
 							<td>
-								<?php echo $this->escape($extensionName); ?>
+								<?php echo $this->escape(JText::_($extension)); ?>
 							</td>
 							<td>
 								<span class="hasTooltip" title="<?php echo JHtml::_('date', $item->log_date, JText::_('DATE_FORMAT_LC6')); ?>">

--- a/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
+++ b/administrator/components/com_actionlogs/views/actionlogs/tmpl/default.php
@@ -62,7 +62,9 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 					</tr>
 				</tfoot>
 				<tbody>
-					<?php foreach ($this->items as $i => $item) : ?>
+					<?php foreach ($this->items as $i => $item) :
+						// Translate extension name here to load translation files before translating message
+						$extensionName = ActionlogsHelper::translateExtensionName(strtok($item->extension, '.')); ?>
 						<tr class="row<?php echo $i % 2; ?>">
 							<td class="center">
 								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
@@ -71,7 +73,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 								<?php echo ActionlogsHelper::getHumanReadableLogMessage($item); ?>
 							</td>
 							<td>
-								<?php echo ActionlogsHelper::translateExtensionName(strtoupper(strtok($this->escape($item->extension), '.'))); ?>
+								<?php echo $this->escape($extensionName); ?>
 							</td>
 							<td>
 								<span class="hasTooltip" title="<?php echo JHtml::_('date', $item->log_date, JText::_('DATE_FORMAT_LC6')); ?>">


### PR DESCRIPTION
Pull Request for Issue #175.

While my initial comment was to add more in regards to being able to opt-out of contacting joomla.org, I think we should have that in the privacy policy on joomla.org. The translation string that I was refering to is a hint what to do, not an exhaustive explanation/documentation, so keep it short(er).

However, in regard to the comment of @neo191987 and the ensuing discussion in #175, I stumbled upon an issue that we already fixed in the CSV export. If an extension logs something into the actionlog and is not in the list of

* com_actionlogs
* system action log plugin
* one of the action log plugin

(Thanks to @joomdonation for that list), then the translation files are not loaded before the layout is called. This would happen with com_privacy or with the terms & conditions plugin from #220. However, the translation file is loaded from the administrator language folder when the extension name is translated, so since the message is translated before the extension name is translated, the result would be that the first message of an extension is not translated, but later messages are. So this pulls the translation of the extension name at the front of the loop, loading the language file before the first message is translated.

We are doing the same thing with the CSV export already and both here and there it didn't feel right... I did some further refactoring to implement loading language files both from the main administrator language folder as well as from the extensions folder. The later feature has some assumptions and thus only tries to load from frontend modules for example.