### PR TITLE
Removing getDatabyPks()

### DIFF
--- a/administrator/components/com_actionlogs/helpers/actionlogs.php
+++ b/administrator/components/com_actionlogs/helpers/actionlogs.php
@@ -129,37 +129,6 @@ class ActionlogsHelper
 	}
 
 	/**
-	 * Method to retrieve data by primary keys from a table
-	 *
-	 * @param   array   $pks      An array of primary key ids of the content that has changed state.
-	 * @param   string  $field    The field to get from the table
-	 * @param   string  $idField  The primary key of the table
-	 * @param   string  $table    The database table to get data from
-	 *
-	 * @return  array
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public static function getDataByPks($pks, $field, $idField, $table)
-	{
-		$db    = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select($db->quoteName(array($idField, $field)))
-			->from($db->quoteName($table))
-			->where($db->quoteName($idField) . ' IN (' . implode(',', ArrayHelper::toInteger($pks)) . ')');
-		$db->setQuery($query);
-
-		try
-		{
-			return $db->loadObjectList($idField);
-		}
-		catch (RuntimeException $e)
-		{
-			return array();
-		}
-	}
-
-	/**
 	 * Get human readable log message for a User Action Log
 	 *
 	 * @param   stdClass  $log  A User Action log message record

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -267,7 +267,14 @@ class PlgActionlogJoomla extends JPlugin
 			$messageLanguageKey = $defaultLanguageKey;
 		}
 
-		$items = ActionlogsHelper::getDataByPks($pks, $params->title_holder, $params->id_holder, $params->table_name);
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select($db->quoteName(array($params->title_holder, $params->id_holder)))
+			->from($db->quoteName($params->table_name))
+			->where($db->quoteName($params->id_holder) . ' IN (' . implode(',', ArrayHelper::toInteger($pks)) . ')');
+		$db->setQuery($query);
+
+		$items = $db->loadObjectList($params->id_holder);
 
 		$messages = array();
 

--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -274,7 +274,14 @@ class PlgActionlogJoomla extends JPlugin
 			->where($db->quoteName($params->id_holder) . ' IN (' . implode(',', ArrayHelper::toInteger($pks)) . ')');
 		$db->setQuery($query);
 
-		$items = $db->loadObjectList($params->id_holder);
+		try
+		{
+			$items = $db->loadObjectList($params->id_holder);
+		}
+		catch (RuntimeException $e)
+		{
+			$items = array();
+		}
 
 		$messages = array();
 


### PR DESCRIPTION
Pull Request for Issue #177.

This removes ActionlogsHelper::getDataByPks(). That method is used exactly once and it is such a generalised method, that it simply does not belong into a component helper like this. You could get the passwords of users with this method as well as the message bodies of com_messages. Either add such a method to the database layer or create a method that is somehow specific to com_actionlogs, but the way it is now, we should simply put the code into the joomla plugin, as I have done here.