### PR TITLE
[Postgresql] - fix backquote to doublequote

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-05.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.0-2018-05-05.sql
@@ -8,7 +8,7 @@ INSERT INTO "#__extensions" ("extension_id", "package_id", "name", "type", "elem
 --
 CREATE TABLE "#__action_logs" (
   "id" serial NOT NULL,
-  `message_language_key` varchar(255) NOT NULL DEFAULT '',
+  "message_language_key" varchar(255) NOT NULL DEFAULT '',
   "message" text NOT NULL DEFAULT '',
   "log_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "extension" varchar(50) NOT NULL DEFAULT '',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -2132,7 +2132,7 @@ COMMENT ON COLUMN "#__user_usergroup_map"."group_id" IS 'Foreign Key to #__userg
 --
 CREATE TABLE "#__action_logs" (
   "id" serial NOT NULL,
-  `message_language_key` varchar(255) NOT NULL DEFAULT '',
+  "message_language_key" varchar(255) NOT NULL DEFAULT '',
   "message" text NOT NULL DEFAULT '',
   "log_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "extension" varchar(50) NOT NULL DEFAULT '',


### PR DESCRIPTION
Pull Request for Issue  
install with postgresql
```
Error
ERROR: syntax error at or near "`" LINE 3: `message_language_key` varchar(255) NOT NULL DEFAULT '', 
``` 
### Summary of Changes
from backquote ` to doublequote "

